### PR TITLE
[Fixup] Fix Header Paths of oplus mtk Power Drivers

### DIFF
--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6893R.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6893R.h
@@ -22,15 +22,15 @@
 #include <linux/uaccess.h>
 
 #include <mt-plat/charger_class.h>
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
 struct charger_manager;
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
 
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_init.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_init.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
 
 typedef enum {
 	STEP_CHG_STATUS_STEP1 = 0,	/*16C~44C*/


### PR DESCRIPTION
* The kernel path for mtk power drivers should be ../drivers/misc/mediatek/ , but for some reasons, the path here is ../../../../kernel-4.14/drivers/misc/mediatek/ , this is probably due to oplus's build system ,
 it works fine in their enviroment, but for third party developer it throws error, , so lets just define its correct path & fix the error 

Test: Error is fixed & kernel code compiles successfully.